### PR TITLE
Fix rubocop.yml

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,30 +1,36 @@
-LineLength:
+AsciiComments:
   Enabled: false
+
+BracesAroundHashParameters:
+  Enabled: false
+
+ClassAndModuleChildren:
+  Enabled: false
+
+# don't enforce arbitrary max class length
+ClassLength:
+  Enabled: false
+
+CyclomaticComplexity:
+  Max: 10
 
 Documentation:
   Enabled: false
 
-RedundantSelf:
-  Enabled: false
-
-BracesAroundHashParameters:
+LineLength:
   Enabled: false
 
 # Avoid methods longer than 10 lines of code
 MethodLength:
   Max: 50
 
-AsciiComments:
-  Enabled: false
+# Avoid parameter lists longer than 5 parameters.
+ParameterLists:
+  Max: 5
+  CountKeywordArgs: false
+  Enabled: true
 
-CyclomaticComplexity:
-  Max: 10
-  
-# don't enforce arbitrary max class length
-ClassLength:
-  Enabled: false
-
-ClassAndModuleChildren:
+RedundantSelf:
   Enabled: false
 
 SignalException:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -37,5 +37,5 @@ SignalException:
   Enabled: false
 
 TrailingCommaInLiteral:
-  Enabled: false
+  EnforcedStyleForMultiline: comma
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,7 +1,3 @@
-AllCops:
-  Exclude:
-    - 'spec/**/*'
-
 AsciiComments:
   Enabled: false
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - 'spec/**/*'
+
 AsciiComments:
   Enabled: false
 
@@ -35,3 +39,7 @@ RedundantSelf:
 
 SignalException:
   Enabled: false
+
+TrailingCommaInLiteral:
+  Enabled: false
+


### PR DESCRIPTION
- rubocop.ymlに次の3つの修正をしました。
  - 設定をABC順に並び替えました。
  - `spec/**/*`のファイルについてはチェックしないようにしました。
  - 複数行にまたがる配列・ハッシュで、末尾行に`,`があるなしに関わらず無視するようにしました。
